### PR TITLE
Add simple site-wide search bar

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,11 @@
       <a href="{{ '/writeups' | relative_url }}">writeups</a> |
       <a href="{{ '/about' | relative_url }}">about</a>
     </nav>
+    <div class="search-bar">
+      <input type="text" id="search-input" placeholder="search">
+      <button id="search-button">search</button>
+    </div>
+    <div id="search-results"></div>
   </header>
   <main>
     {{ content }}
@@ -20,5 +25,6 @@
   <footer>
     <p>&copy; {{ site.title }}</p>
   </footer>
+  <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
 </body>
 </html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,3 +16,26 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+.search-bar input {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #0f0;
+  color: #0f0;
+}
+
+.search-bar input::placeholder {
+  color: #0f0;
+}
+
+.search-bar button {
+  background: transparent;
+  border: 1px solid #0f0;
+  color: #0f0;
+  cursor: pointer;
+  margin-left: 0.5rem;
+}
+
+#search-results div {
+  margin-top: 0.5rem;
+}

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,40 @@
+---
+---
+function initSearch() {
+  var input = document.getElementById('search-input');
+  var button = document.getElementById('search-button');
+  var results = document.getElementById('search-results');
+  if (!input || !button || !results) return;
+
+  var indexData = [];
+  fetch('{{ "/search.json" | relative_url }}')
+    .then(function(res) { return res.json(); })
+    .then(function(data) { indexData = data; });
+
+  function search() {
+    var query = input.value.trim().toLowerCase();
+    results.innerHTML = '';
+    if (!query) return;
+    var matches = indexData.filter(function(item) {
+      return item.content.toLowerCase().indexOf(query) !== -1 ||
+             item.title.toLowerCase().indexOf(query) !== -1;
+    });
+    matches.forEach(function(item) {
+      var div = document.createElement('div');
+      var a = document.createElement('a');
+      a.href = item.url;
+      a.textContent = item.title;
+      div.appendChild(a);
+      results.appendChild(div);
+    });
+  }
+
+  button.addEventListener('click', search);
+  input.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') {
+      search();
+    }
+  });
+}
+
+document.addEventListener('DOMContentLoaded', initSearch);

--- a/search.json
+++ b/search.json
@@ -1,0 +1,15 @@
+---
+layout: null
+---
+[
+  {% assign pages = site.pages | where_exp: "page", "page.search_exclude != true" %}
+  {% assign writeups = site.writeups | where_exp: "page", "page.search_exclude != true" %}
+  {% assign all_pages = pages | concat: writeups %}
+  {% for page in all_pages %}
+  {
+    "title": "{{ page.title | escape }}",
+    "url": "{{ page.url | relative_url }}",
+    "content": {{ page.content | markdownify | strip_html | jsonify }}
+  }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]


### PR DESCRIPTION
## Summary
- add minimalist search bar with button and results
- index site content into `search.json`
- implement client-side search in `assets/js/search.js`

## Testing
- `bundle install` *(fails: Gem::Net::HTTPClientException 403 "Forbidden")*
- `bundle exec jekyll build` *(fails: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_68b326fde34c832d88751c19f3084b51